### PR TITLE
Clean up dependencies in gradle build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,28 +1,29 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         applicationId "com.zendrive.zendrivesdkdemo"
         minSdkVersion 14
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode 1
         versionName "1.0"
 
-        // Enabling multidex support.
+        // Enabling multidex support. Not explicitly required for sample
         multiDexEnabled true
     }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -31,33 +32,23 @@ android {
     }
 
     lintOptions {
-        // This is needed to avoid spurious lint errors from libthrift and log4j on android.
+        // This is needed to avoid spurious lint errors from libthrift on android.
         disable 'InvalidPackage'
     }
+
     packagingOptions {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
 }
 
-repositories {
-    mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/groups/public' }
-}
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-
-    compile 'com.android.support:multidex:1.0.0'
-
-    compile 'com.google.android.gms:play-services-location:6.5.+'
-    compile 'com.google.code.gson:gson:2.2.4'
-
-    compile 'com.amazonaws:aws-android-sdk-core:2.1.3'
+    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.google.code.gson:gson:2.3'
     compile 'com.amazonaws:aws-android-sdk-sqs:2.1.3'
-    compile 'org.slf4j:slf4j-api:1.5.8'
-    compile 'org.slf4j:slf4j-log4j12:1.5.8'
-    compile 'org.apache.thrift:libthrift:0.9.1+'
-    compile 'com.github.kohanyirobert:ebson:0.4-SNAPSHOT'
+    compile 'com.google.android.gms:play-services-location:7.5.0'
+    compile ('org.apache.thrift:libthrift:0.9.2') {
+        exclude group: 'org.apache.httpcomponents'
+    }
 }
-

--- a/app/src/main/java/com/zendrive/zendrivesdkdemo/MainFragment.java
+++ b/app/src/main/java/com/zendrive/zendrivesdkdemo/MainFragment.java
@@ -1,5 +1,12 @@
 package com.zendrive.zendrivesdkdemo;
 
+import com.zendrive.sdk.DriveInfo;
+import com.zendrive.sdk.DriveStartInfo;
+import com.zendrive.sdk.Zendrive;
+import com.zendrive.sdk.ZendriveConfiguration;
+import com.zendrive.sdk.ZendriveDriverAttributes;
+import com.zendrive.sdk.ZendriveListener;
+
 import android.app.AlertDialog;
 import android.app.Fragment;
 import android.content.DialogInterface;
@@ -11,13 +18,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
-
-import com.zendrive.sdk.DriveInfo;
-import com.zendrive.sdk.DriveStartInfo;
-import com.zendrive.sdk.Zendrive;
-import com.zendrive.sdk.ZendriveConfiguration;
-import com.zendrive.sdk.ZendriveDriverAttributes;
-import com.zendrive.sdk.ZendriveListener;
 
 public class MainFragment extends Fragment {
 
@@ -65,6 +65,7 @@ public class MainFragment extends Fragment {
         loadingIndicatorParent.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
+                v.performClick();
                 return true;
             }
         });

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -46,7 +46,7 @@
             android:layout_height="wrap_content"
             android:id="@+id/restartSDKButton"
             android:layout_above="@+id/startEndParent"
-            android:text="Restart Zendrive SDK" />
+            android:text="@string/restart_zen_sdk" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="app_name">ZendriveSDKDemo</string>
     <string name="start_drive">Start Drive</string>
     <string name="end_drive">End Drive</string>
+    <string name="restart_zen_sdk">Restart Zendrive SDK</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+org.gradle.daemon=true


### PR DESCRIPTION
Some declared dependencies are not required for full functionality
Remove `slf4j`
Remove `ebson` snapshot build
Keep apache thrift but remove `httpcomponents` package as it conflicts
  with android's included classpaths
Remove aws core lib as only sqs lib is requried
Remove `mavenCentral` repository in favor of AS prefered `jcenter`
  repository
Remove unused sonatype repository

Updated versions to the latest for
targetSdkVersion: `21 -> 22`
buildToolsVersion: `22.0.1 -> 21.1.1`
android gradle tools: `1.0.0 -> 1.2.3`
android support multidex: `1.0.0 -> 1.0.1`
apache libthrift: `0.9.1+ -> 0.9.2`
google gson: `2.2.4 -> 2.3`

Lint warning fix in MainFragment.  Implementations of `View$OnTouchListener` should
  also call `View#performClick()`

Add daemon to gradle properties

Move hardcoded reset sdk string to `R.string.blah` reference
